### PR TITLE
Configure Dependabot to update the fastlane gemfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "bundler"
+    directory: "/android"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This will allow Dependabot to update the `/android/Gemfile.lock` file.
We have some security vulnarabillity alerts that will hopefully be fixed by this.